### PR TITLE
Add Terraform config for ECR and EC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Terraform files
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,58 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+# ECR Repositories
+resource "aws_ecr_repository" "webapp" {
+  name         = "webapp"
+  force_delete = true
+}
+
+resource "aws_ecr_repository" "mysql" {
+  name         = "mysql"
+  force_delete = true
+}
+
+# Security Group
+resource "aws_security_group" "ec2_security_group" {
+  name        = "ec2-security-group"
+  description = "Security group for EC2 instance"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8081
+    to_port     = 8083
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# EC2 Instance
+resource "aws_instance" "app_server" {
+  ami           = var.ami_id
+  instance_type = "t2.micro"
+
+  vpc_security_group_ids = [aws_security_group.ec2_security_group.id]
+
+  # Use the existing LabInstanceProfile
+  iam_instance_profile = "LabInstanceProfile"
+
+  key_name = "vockey"
+
+  tags = {
+    Name = "CLO835-Assignment1"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_public_ip" {
+  description = "Public IP of the EC2 instance"
+  value       = aws_instance.app_server.public_ip
+}
+
+output "webapp_repository_url" {
+  description = "URL of the webapp ECR repository"
+  value       = aws_ecr_repository.webapp.repository_url
+}
+
+output "mysql_repository_url" {
+  description = "URL of the MySQL ECR repository"
+  value       = aws_ecr_repository.mysql.repository_url
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 instance"
+  type        = string
+  default     = "ami-085ad6ae776d8f09c"
+}


### PR DESCRIPTION
This PR adds Terraform config to create:
main.tf
outputs.tf
variables.tf
.gitignore file that ignores tfstate files which are not needed 